### PR TITLE
Remove reserved word interface

### DIFF
--- a/lib/byte-converter.js
+++ b/lib/byte-converter.js
@@ -47,10 +47,9 @@ function _isEmpty(s) {
     }
     return false;
 }
-var interface = {
+
+module.exports = {
     converterBase10: converter,
     converterBase2: convertBase2,
     getSmallestUnit: getSmallestUnit
 };
-
-module.exports = interface;


### PR DESCRIPTION
Error when bundling with webpack because of reserved word "interface"